### PR TITLE
corrected the spellings of lookupCache and responseCache beckn/protocol-server#27

### DIFF
--- a/src/routes/protocol.ts
+++ b/src/routes/protocol.ts
@@ -57,7 +57,7 @@ Object.keys(ActionTypes).forEach((action) => {
     }
 })
 
-router.delete('/lookupCacbe', async (req: Request, res: Response, next: NextFunction) => {
+router.delete('/lookupCache', async (req: Request, res: Response, next: NextFunction) => {
     try {
         const lookupCache = LookupCache.getInstance();
         await lookupCache.clear();
@@ -69,7 +69,7 @@ router.delete('/lookupCacbe', async (req: Request, res: Response, next: NextFunc
         next(error)
     }
 });
-router.delete('/responseCacbe', async (req: Request, res: Response, next: NextFunction) => {
+router.delete('/responseCache', async (req: Request, res: Response, next: NextFunction) => {
     try {
         const responseCache = ResponseCache.getInstance();
         await responseCache.clear();


### PR DESCRIPTION
In the `/src/routes/protocol.ts` file I corrected the spellings of 
`lookupCacbe` to `lookupCache` endpoint in line 60 
https://github.com/beckn/protocol-server/blob/20c2be50dba396e6e4f9a9799e676eec41ee1c0b/src/routes/protocol.ts#L60
`responseCacbe` to `responseCache` endpoint in line 72
https://github.com/beckn/protocol-server/blob/20c2be50dba396e6e4f9a9799e676eec41ee1c0b/src/routes/protocol.ts#L72