### PR TITLE
Removing format: phone from Support schema as the format isn't allowed by OpenAPI.

### DIFF
--- a/schemas/core_1.1.0.yaml
+++ b/schemas/core_1.1.0.yaml
@@ -2034,10 +2034,8 @@ components:
           type: string
         callback_phone:
           type: string
-          format: phone
         phone:
           type: string
-          format: phone
         email:
           type: string
           format: email


### PR DESCRIPTION
The Support schema has 2 phone-related properties with the `format: phone` that isn't supported by the OpenAPI validator. It throws the following error. 

**Due to this, support APIs don't work for 1.1.0 spec**

![MicrosoftTeams-image](https://github.com/beckn/protocol-server/assets/14144849/487db92b-3b60-465c-8827-f9f7060c0e75)

I spoke to Ravi too about this and he asked me to remove this from the 1.2.0 spec that is upcoming. 