### PR TITLE
Fixing Incorrect Installation Command in setup.md

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -247,7 +247,7 @@ publicKey: "asRiVjIEHc2yu6ungf+oHSHHqfxUc8fA0Bj8NjjhZt0="
   httpRetryCount: 2
 ```
 
-6. Execute the command `npm run install` to npm packages.
+6. Execute the command `npm install` to npm packages.
 7. Execute the command `npm run dev` to start the server.
 
 ## Protocol Server BAP Network Setup
@@ -421,7 +421,7 @@ httpTimeout: "PT3S"
 httpRetryCount: 2
 ```
 
-6. Execute the command `npm run install` to npm packages.
+6. Execute the command `npm install` to npm packages.
 7. Execute the command `npm run dev` to start the server.
 8. Make the BAP Network server publicly accessible by using6. Execute the command `npm run dev` to start the server. tools like [localtunnel](https://theboroer.github.io/localtunnel-www), [ngrok](https://ngrok.com/docs), [loophole](https://loophole.cloud/docs). This **public url** will be used in `config/default.yml` and `Beckn registry`.
 
@@ -598,7 +598,7 @@ cp config/config-sample-client-localhost.yaml config/default.yml
   httpRetryCount: 2
 ```
 
-6. Execute the command `npm run install` to npm packages.
+6. Execute the command `npm install` to npm packages.
 7. Execute the command `npm run dev` to start the server.
 
 ## Protocol Server BPP Network Setup
@@ -774,6 +774,6 @@ httpTimeout: "PT3S"
 httpRetryCount: 2
 ```
 
-6. Execute the command `npm run install` to npm packages.
+6. Execute the command `npm install` to npm packages.
 7. Execute the command `npm run dev` to start the server.
 8. Make the BPP Network server publicly accessible by using tools like [localtunnel](https://theboroer.github.io/localtunnel-www), [ngrok](https://ngrok.com/docs), [loophole](https://loophole.cloud/docs). This **public url** will be used in `config/default.yml` and `Beckn registry`.


### PR DESCRIPTION
In this pull request, I've addressed an issue in the setup.md file regarding an incorrect installation command. The file previously instructed users to run npm run install to install packages, which is technically incorrect. The correct command for installing packages using npm is npm install.

To align the instructions with the proper npm package installation process, I've made the necessary changes to the setup.md file. I replaced the incorrect command with the accurate npm install command. This simple but crucial fix ensures that users will have accurate instructions to follow when setting up the project and installing packages.

This commit resolves the inconsistency in the setup.md file and provides clear and accurate instructions for package installation using npm.