### PR TITLE
Fixed: Set debug as default log level when /logs api is called withou…

### DIFF
--- a/src/routes/requests.routes.ts
+++ b/src/routes/requests.routes.ts
@@ -26,7 +26,8 @@ export const requestsRouter = Router();
 
 requestsRouter.get("/logs", (req, res) => {
   try {
-    const logLevel: LogLevelEnum = req?.query?.type as LogLevelEnum;
+    const logLevel: LogLevelEnum =
+      (req?.query?.type as LogLevelEnum) || LogLevelEnum.DEBUG;
     const files = fs.readdirSync(
       path.join(__dirname + `../../../logs/${logLevel}`)
     );


### PR DESCRIPTION
…t any query parameter for log type