### PR TITLE
Updated Schema Validator to support openapi 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express": "^4.18.1",
     "express-openapi-validator": "^5.1.6",
     "express-status-monitor": "^1.3.4",
+    "openapi-backend": "^5.11.0",
     "ioredis": "^5.0.6",
     "libsodium-wrappers": "^0.7.9",
     "mongodb": "^4.7.0",

--- a/src/utils/redis.utils.ts
+++ b/src/utils/redis.utils.ts
@@ -52,6 +52,9 @@ export class RedisClient {
     }
     
     async setWithExpiry(key: string, value: string, expiry: number) : Promise<boolean> {
+        if (!Number.isInteger(expiry) || expiry <= 0) {
+            expiry = 400;
+        }
         if(this.cacheEnabled){
             return await this.redis!.set(key, value, "EX", expiry) === "OK";
         }


### PR DESCRIPTION
This PR introduces modifications to the validation layer of the protocol server to enhance its OpenAPI validation capabilities, specifically targeting OpenAPI 3.1.0 specifications. Key changes include:

**Package Update:**

-  Added openapi-backend version 5.11.0 to package.json. This library was chosen as an alternative to express-openapi-validator due to its limitations in handling certain validation keywords, such as contains, introduced in OpenAPI 3.1.0.

**Migration to openapi-backend:**

- The validation middleware has been completely refactored to replace express-openapi-validator, which could not fully support OpenAPI 3.1.0 schemas, even with the latest alpha releases.

- A custom middleware has been developed using openapi-backend to handle request validations in a manner consistent with the previous behavior of express-openapi-validator. This custom middleware ensures that validation errors are caught and managed properly, while also allowing validated requests to pass through to subsequent middleware.

        
**Redis Utility Update:**

- Updated the setWithExpiry method in the Redis utility to include a fallback mechanism for setting the expiry time. The updated logic ensures that if the provided expiry is not a positive integer, it defaults to 400 seconds: